### PR TITLE
Add frontend env example and note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ A web application for managing band rehearsal room bookings, built with React, N
    # Edit frontend/.env with your configuration
    ```
 
+   After copying the example file, update `VITE_API_URL` in `frontend/.env` if your backend runs on a different host or port.
+
 4. Start the development environment:
    ```bash
    # Using SQLite (default configuration)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:4000/api


### PR DESCRIPTION
## Summary
- add `frontend/.env.example`
- mention copying `.env.example` and updating `VITE_API_URL`

## Testing
- `npm test` (backend, fails: Permission denied)
- `npm test` (frontend, fails: Permission denied)

------
https://chatgpt.com/codex/tasks/task_e_684da9ce9d9083329f822b006421291c