### PR TITLE
Add backend ESLint setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ A web application for managing band rehearsal room bookings, built with React, N
    ```bash
    ./scripts/test-backend.sh
    ```
+
+4. Lint the code:
+   ```bash
+   cd backend
+   npm run lint
+   ```
   
 ### Frontend Development
 

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  env: {
+    node: true,
+    es2021: true
+  },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  ignorePatterns: ['dist/', 'node_modules/']
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "test": "jest",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev"
+    "prisma:migrate": "prisma migrate dev",
+    "lint": "eslint . --ext ts"
   },
   "dependencies": {
     "@prisma/client": "^5.10.0",
@@ -37,6 +38,9 @@
     "prisma": "^5.10.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint configuration for backend with TypeScript rules
- include lint script in backend package.json
- document how to run the linter

## Testing
- `./scripts/test-backend.sh` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684da9f07b588332ba6e6c9aace0a1b0