### PR TITLE
Add backend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A web application for managing band rehearsal room bookings, built with React, N
    npx prisma generate
    ```
 
-3. Run tests:
+3. Run tests (located in `backend/tests`):
    ```bash
    ./scripts/test-backend.sh
    ```

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -43,14 +43,18 @@ app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-// Start server
+// Start server when executed directly
 const PORT = process.env.PORT || 4000;
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+  });
+}
 
 // Handle shutdown
 process.on('SIGINT', async () => {
   await prisma.$disconnect();
   process.exit(0);
-}); 
+});
+
+export default app;

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -1,0 +1,42 @@
+jest.mock('@prisma/client', () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      $disconnect: jest.fn(),
+    })),
+  };
+});
+
+import app from '../src/index';
+import { AddressInfo } from 'net';
+
+// Helper to perform fetch requests using the started server
+const getUrl = (path: string) => {
+  const { port } = server.address() as AddressInfo;
+  return `http://localhost:${port}${path}`;
+};
+
+let server: ReturnType<typeof app.listen>;
+
+beforeAll(done => {
+  server = app.listen(0, done);
+});
+
+afterAll(done => {
+  server.close(done);
+});
+
+describe('Health Check', () => {
+  it('responds with status ok on /health', async () => {
+    const res = await fetch(getUrl('/health'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok' });
+  });
+
+  it('responds with status ok on /api/health', async () => {
+    const res = await fetch(getUrl('/api/health'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Run backend tests without relying on npm
-node backend/node_modules/jest/bin/jest.js "${@}"
+node backend/node_modules/jest/bin/jest.js --config backend/jest.config.js "$@"


### PR DESCRIPTION
## Summary
- export express app for testing
- add Jest config and health endpoint test
- update test-backend script to use config
- document backend tests in README

## Testing
- `./scripts/test-backend.sh --silent`

------
https://chatgpt.com/codex/tasks/task_e_684da9f1370883328287d403935f1bd2