### PR TITLE
Fix Postgres variable name in backend docker-compose

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     image: postgres:14-alpine
     environment:
       POSTGRES_USER: user
-      POSTGS_PASSWORD: password
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: booking_system
     volumes:
       - db_data:/var/lib/postgresql/data


### PR DESCRIPTION
## Summary
- correct the database password variable in backend compose config

## Testing
- `./scripts/test-backend.sh`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684db3e842588332ad30f972a8e001c4