### PR TITLE
Add frontend Dockerfile and update compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "5173:5173"
+      - "5173:80"
     environment:
       VITE_API_URL: http://localhost:3000/api
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+COPY . .
+RUN npm install
+RUN npm run build
+
+# Production stage
+FROM nginx:stable-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- build frontend with Node and serve with nginx
- map frontend container port to 80 in docker-compose

## Testing
- `npm test` (fails: `jest: Permission denied`)
- `npm test` in frontend (fails: `vitest: Permission denied`)


------
https://chatgpt.com/codex/tasks/task_e_684db3ea5818833294f947eeb7414f60