### PR TITLE
Add Docker ignore files

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+*.log
+**/*.log

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+*.log
+**/*.log


### PR DESCRIPTION
## Summary
- add `.dockerignore` to `backend` and `frontend`
- these ignore `node_modules`, `dist`, `coverage`, and log files

## Testing
- `bash scripts/test-backend.sh`
- `sh frontend/node_modules/.bin/vitest run` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `docker build -t backend-test-image backend/` *(fails: command not found)*
- `docker build -t frontend-test-image frontend/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de76915d483328a2c76c6b3735652