### PR TITLE
Update Dockerfiles to use npm ci

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma/
 
-RUN npm install
+RUN npm ci --omit=dev
 
 COPY . .
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 COPY . .
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 # Production stage


### PR DESCRIPTION
## Summary
- use `npm ci --omit=dev` in backend Dockerfile
- use `npm ci` in frontend Dockerfile
- verify backend tests pass

## Testing
- `./scripts/test-backend.sh`
- `docker build -t backend-test-image ./backend` *(fails: `docker` command not found)*
- `docker build -t frontend-test-image ./frontend` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de76ae1008332860b2a85cdce17f4