### PR TITLE
Fix Express typings in backend

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -105,7 +105,6 @@ export const validateTokenHandler = async (req: Request, res: Response): Promise
   // and attached user information to req.user.
   
   // The JWT payload is expected to be on req.user (set by authMiddleware)
-  // @ts-expect-error -- Express.Request is augmented with user property elsewhere
   const tokenUser = req.user;
 
   if (!tokenUser || !tokenUser.userId) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -35,13 +35,11 @@ app.use('/api/admin', authenticate, requireAdmin, adminRoutes);
 
 // Basic health check route
 app.get('/health', (_req: Request, res: Response) => {
-  // @ts-expect-error - middleware typing
   res.json({ status: 'ok' });
 });
 
 // Additional health check route
 app.get('/api/health', (_req: Request, res: Response) => {
-  // @ts-expect-error - middleware typing
   res.json({ status: 'ok' });
 });
 

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -7,4 +7,6 @@ declare module 'express-serve-static-core' {
       bandId?: string;
     };
   }
-} 
+}
+
+export {};

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -25,7 +25,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "types": ["node", "express"]
   },
   "exclude": ["node_modules"],
   "include": ["./src/**/*.ts"]


### PR DESCRIPTION
## Summary
- augment Express `Request` type correctly
- include Express typings in backend TypeScript config
- remove leftover `@ts-expect-error` directives causing build failures

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684de7663cd08332af110928d4ea1bf5