### PR TITLE
Update Docker production start scripts

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,12 +5,13 @@ WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma/
 
-RUN npm ci --omit=dev
+RUN npm ci
 
 COPY . .
 
 RUN npm run build
+RUN npm prune --omit=dev
 
 EXPOSE 3000
 
-CMD ["npm", "start"] 
+CMD ["npm", "run", "start:prod"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "ts-node src/index.ts",
     "dev": "nodemon src/index.ts",
+    "start:prod": "node dist/index.js",
     "build": "tsc",
     "test": "jest",
     "prisma:generate": "prisma generate",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "3000:3000"
     depends_on:
       - postgres
-    command: sh -c "npx prisma migrate deploy && npm start"
+    command: sh -c "npx prisma migrate deploy && npm run start:prod"
 
   frontend:
     build: ./frontend


### PR DESCRIPTION
## Summary
- add a `start:prod` script to run compiled code
- adjust backend Dockerfile to install deps, prune dev deps and run the prod script
- update docker-compose to call the new start command

## Testing
- `node backend/node_modules/jest/bin/jest.js` *(fails: Cannot parse TypeScript)*
- `npx jest` *(fails: prompts to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684dea7c16f483328510c1e3634c4536