### PR TITLE
Add admin setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ A web application for managing band rehearsal room bookings, built with React, N
    npm install
    ```
 
-3. Set up environment variables:
+3. Generate Prisma client and create the default admin user:
+   ```bash
+   cd backend
+   npx prisma generate
+   npx ts-node prisma/fix-admin.ts
+   cd ..
+   ```
+4. Set up environment variables:
    ```bash
    # Backend
    cp backend/.env.example backend/.env

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- document how to create the default admin user
- ensure Prisma client works in Linux by specifying binary targets

## Testing
- `sh scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_684df40fd01883329eae9faf98a36d87