### PR TITLE
Add automatic admin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ A web application for managing band rehearsal room bookings, built with React, N
    npm install
    ```
 
-3. Set up environment variables:
+3. Generate the Prisma client (a default admin user will be created on first run):
+   ```bash
+   cd backend
+   npx prisma generate
+   cd ..
+   ```
+4. Set up environment variables:
    ```bash
    # Backend
    cp backend/.env.example backend/.env
@@ -87,6 +93,10 @@ A web application for managing band rehearsal room bookings, built with React, N
 5. Access the application:
    - Frontend: http://localhost:5173 (or another port if 5173 is in use)
    - Backend API: http://localhost:3000
+
+   The backend will automatically create a default admin account
+   (**admin@admin.com** / **admin**) if none exists. Be sure to change the
+   password after the first login.
 
 ## Backend Environment Variables
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import { PrismaClient } from '@prisma/client';
+import { ensureDefaultAdmin } from './utils/ensureAdmin';
 
 // Import routes
 import authRoutes from './routes/auth.routes';
@@ -46,9 +47,13 @@ app.get('/api/health', (_req: Request, res: Response) => {
 // Start server when executed directly
 const PORT = process.env.PORT || 3000;
 if (require.main === module) {
-  app.listen(PORT, () => {
-    console.log(`Server is running on port ${PORT}`);
-  });
+  ensureDefaultAdmin(prisma)
+    .catch(err => console.error('Failed to ensure default admin', err))
+    .finally(() => {
+      app.listen(PORT, () => {
+        console.log(`Server is running on port ${PORT}`);
+      });
+    });
 }
 
 // Handle shutdown

--- a/backend/src/utils/ensureAdmin.ts
+++ b/backend/src/utils/ensureAdmin.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
+import bcrypt from 'bcryptjs';
+
+export async function ensureDefaultAdmin(prisma: PrismaClient): Promise<void> {
+  const email = 'admin@admin.com';
+  const password = 'admin';
+
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (!existing) {
+    await prisma.user.create({
+      data: {
+        id: uuidv4(),
+        email,
+        password: await bcrypt.hash(password, 10),
+        role: 'ADMIN'
+      }
+    });
+    console.log('Default admin user created');
+  }
+}


### PR DESCRIPTION
## Summary
- add `ensureDefaultAdmin` helper to create admin automatically
- call admin helper on server startup
- update README with new instructions and default login details

## Testing
- `sh scripts/test-backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_684df40fd01883329eae9faf98a36d87