### PR TITLE
Add default admin credentials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,14 @@ A web application for managing band rehearsal room bookings, built with React, N
    - Frontend: http://localhost:5173 (or another port if 5173 is in use)
    - Backend API: http://localhost:3000
 
-   The backend will automatically create a default admin account
-   (**admin@admin.com** / **admin**) if none exists. Be sure to change the
-   password after the first login.
+### Default Admin Credentials
+
+The backend will automatically create a default admin account if none exists:
+
+- **Email**: `admin@admin.com`
+- **Password**: `admin`
+
+Be sure to change the password after the first login.
 
 ## Backend Environment Variables
 


### PR DESCRIPTION
## Summary
- document the default admin login information in `README.md`

## Testing
- `./scripts/test-backend.sh`
- `npm --prefix backend run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_684eb0ac55f08332af98e83cd9b66a3a