### PR TITLE
Clarify env example

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
-# URL of the backend service when running via docker-compose
+# URL of the backend service.
+# Set to `http://backend:3000/api` when using `docker-compose`.
+# For local development without Docker, set the value to `http://localhost:3000/api`.
 VITE_API_URL=http://backend:3000/api
-VITE_API_URL=http://localhost:3000/api


### PR DESCRIPTION
## Summary
- deduplicate and clarify VITE_API_URL instructions in `frontend/.env.example`

## Testing
- `node node_modules/jest/bin/jest.js` *(fails: File not found: ./backend/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_684eba52df7c8332b81ad2b014ca7606