### PR TITLE
Fix login API base URL

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -24,7 +24,10 @@ const Login = () => {
           navigate('/calendar');
         }
       })
-      .catch((err: unknown) => setError('Invalid email or password'));
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Login failed';
+        setError(message);
+      });
   };
 
   return (

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 
 // Create axios instance with base URL
+// If VITE_API_URL is not set, default to '/api'
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_API_URL || '/api',
 });
 
 let isRefreshing = false;


### PR DESCRIPTION
## Summary
- default axios base URL to `/api` when `VITE_API_URL` isn't configured

## Testing
- `npm run lint` in frontend
- `npm test` *(fails: vitest: Permission denied)*
- `./scripts/test-backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_684ebedbdb908332883b524b040a1834