### PR TITLE
Fix backend Dockerfile OpenSSL issue

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:18-alpine
 
+# Ensure Prisma can detect OpenSSL
+RUN apk add --no-cache openssl
+
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
## Summary
- install OpenSSL in backend Dockerfile so Prisma works properly

## Testing
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ec82b725c8332809cdb5e6e55c175