### PR TITLE
Fix dev login by proxying API

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,5 +13,13 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173,
+    // Proxy API requests to the backend during development.
+    // This allows the app to work even if VITE_API_URL is not set.
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
-}); 
+});


### PR DESCRIPTION
## Summary
- fix dev server config so `/api` requests proxy to backend

## Testing
- `npm run lint` in `frontend`
- `npm run lint` in `backend` *(fails: ESLint couldn't find config)*
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ec7df468c83328a39abb4ab9eaed8