### PR TITLE
Fix login failing on Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ A web application for managing band rehearsal room bookings, built with React, N
    # Set DATABASE_URL to your PostgreSQL connection string
 
    # Frontend
-   cp frontend/.env.example frontend/.env
-   # Edit frontend/.env with your configuration
-   ```
+  cp frontend/.env.example frontend/.env
+  # Edit frontend/.env with your configuration
+  ```
 
-   After copying the example file, update `VITE_API_URL` in `frontend/.env` if your backend runs on a different host or port.
+  After copying the example file, update `VITE_API_URL` in `frontend/.env` if your backend runs on a different host or port. When using
+  `docker-compose`, the backend is available on `http://localhost:3000/api`.
 
 4. Start the development environment:
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,12 +31,17 @@ services:
     command: sh -c "npx prisma migrate deploy && npm run start:prod"
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        # The frontend is served to the host's browser, so it must talk to
+        # localhost to reach the backend exposed on port 3000.
+        - VITE_API_URL=http://localhost:3000/api
     ports:
       - "5173:80"
     environment:
-      # Point the frontend to the backend service when running with Docker
-      VITE_API_URL: http://backend:3000/api
+      # Point the frontend to the backend running on the host
+      VITE_API_URL: http://localhost:3000/api
     depends_on:
       - backend
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
 # URL of the backend service.
-# Set to `http://backend:3000/api` when using `docker-compose`.
-# For local development without Docker, set the value to `http://localhost:3000/api`.
-VITE_API_URL=http://backend:3000/api
+# When using Docker, your browser accesses the backend via localhost,
+# so the default should point to `http://localhost:3000/api`.
+VITE_API_URL=http://localhost:3000/api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,12 @@ FROM node:18-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 COPY . .
+
+# Allow API URL to be specified at build time so the frontend
+# knows where to send requests when running inside Docker
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+
 RUN npm ci
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- fix API URL used in docker-compose
- document the localhost API address for docker
- update frontend env example

## Testing
- `./scripts/test-backend.sh --runTestsByPath backend/tests/login.test.ts`
- `./scripts/test-backend.sh`


------
https://chatgpt.com/codex/tasks/task_e_684ecd34412c8332b7e7bda7d531ee98