### PR TITLE
Fix default API URL to prevent login failures

### DIFF
--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -1,9 +1,11 @@
 import axios from 'axios';
 
 // Create axios instance with base URL
-// If VITE_API_URL is not set, default to '/api'
+// If VITE_API_URL is not set, default to the local backend.
+// This helps avoid login failures when the frontend is started
+// without a configured environment file.
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
 });
 
 let isRefreshing = false;


### PR DESCRIPTION
## Summary
- set a sensible fallback API URL in Axios config so login works out of the box

## Testing
- `node backend/node_modules/jest/bin/jest.js --config backend/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_684eec5fdcd48332b6bedb2f27d5256d