### PR TITLE
Fix API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ A web application for managing band rehearsal room bookings, built with React, N
   # Edit frontend/.env with your configuration
   ```
 
-  After copying the example file, update `VITE_API_URL` in `frontend/.env` if your backend runs on a different host or port. When using
-  `docker-compose`, the backend is available on `http://localhost:3000/api`.
+  After copying the example file, you can set `VITE_API_URL` in `frontend/.env` if
+  your backend runs on a different host or port. When left empty, the frontend
+  defaults to the relative path `/api`, which works as long as the backend is
+  reachable from the same host. With `docker-compose`, the backend is available
+  at `http://localhost:3000`.
 
 4. Start the development environment:
    ```bash

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,2 @@
-VITE_API_URL=http://localhost:3000/api
+# Leave empty to use the same host the frontend is served from.
+VITE_API_URL=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,5 @@
 # URL of the backend service.
-# When using Docker, your browser accesses the backend via localhost,
-# so the default should point to `http://localhost:3000/api`.
-VITE_API_URL=http://localhost:3000/api
+# When running the frontend from the same host as the backend,
+# you can leave this empty. The app will default to "/api".
+# Set a full URL here if the backend is served from another domain.
+VITE_API_URL=

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -5,7 +5,11 @@ import axios from 'axios';
 // This helps avoid login failures when the frontend is started
 // without a configured environment file.
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:3000/api',
+  // If no VITE_API_URL is provided, default to using a relative
+  // path so the frontend communicates with the same host that served
+  // the application. This avoids hard coding "localhost" which breaks
+  // when accessing the app via an IP or different domain.
+  baseURL: import.meta.env.VITE_API_URL || '/api',
 });
 
 let isRefreshing = false;


### PR DESCRIPTION
## Summary
- default axios base URL to `/api` so deployments don't hard-code localhost
- document the new behaviour in README
- update example `.env` files

## Testing
- `npm run lint` in `frontend`
- `npm test` in `frontend` *(fails: vitest Permission denied)*
- `npm run lint` in `backend` *(fails: ESLint couldn't find config)*
- `../scripts/test-backend.sh` *(fails: Cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_684ef41b69008332b196b3b750e57a7a