### PR TITLE
Update design with pastel theme

### DIFF
--- a/README_DESIGN.md
+++ b/README_DESIGN.md
@@ -2,4 +2,6 @@
 
 This app supports light and dark themes. Use the toggle in the top-right corner to switch modes. The initial theme matches your operating system preference and is stored in local storage.
 
-Custom colours are defined in `tailwind.config.js` using CSS HSL variables (`--color-primary`, `--color-muted-50`, `--color-muted-950`). Extend the palette by adding more variables and referencing them inside the config.
+Custom colours are defined in `globals.css` and referenced in `tailwind.config.js`.
+The primary palette uses a soft blue tone for a smoother look. Light and dark themes
+share the same variables, so updating them in `:root` automatically adjusts the entire UI.

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -20,8 +20,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   };
 
   return (
-    <div className="min-h-screen text-gray-900 dark:text-gray-100 bg-gradient-to-br from-sky-50 via-teal-50 to-violet-100 dark:from-gray-950 dark:via-gray-900 dark:to-gray-800">
-      <nav className="backdrop-blur-md bg-gradient-to-r from-cyan-500 via-sky-600 to-fuchsia-600 dark:from-gray-800 dark:to-gray-700 shadow-sm border-b border-white/10">
+    <div className="min-h-screen text-gray-900 dark:text-gray-100 bg-gradient-to-br from-muted-50 via-accent to-muted-50 dark:from-muted-950 dark:via-accent dark:to-muted-950">
+      <nav className="backdrop-blur-md bg-gradient-to-r from-primary/80 via-primary to-primary/80 dark:from-muted-950 dark:via-primary dark:to-muted-950 shadow-sm border-b border-white/10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16 items-center">
             <div className="flex">

--- a/frontend/src/components/calendar/BookingModal.tsx
+++ b/frontend/src/components/calendar/BookingModal.tsx
@@ -150,7 +150,7 @@ const BookingModal = ({
                   newDate.setHours(parseInt(hours), parseInt(minutes));
                   setFormData({ ...formData, start: newDate.toISOString() });
                 }}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-[#FF5722]"
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-primary"
               />
             </div>
 
@@ -167,7 +167,7 @@ const BookingModal = ({
                   newDate.setHours(parseInt(hours), parseInt(minutes));
                   setFormData({ ...formData, end: newDate.toISOString() });
                 }}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-[#FF5722]"
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-primary"
               />
             </div>
 
@@ -180,7 +180,7 @@ const BookingModal = ({
                 onChange={(e) =>
                   setFormData({ ...formData, roomId: e.target.value })
                 }
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-[#FF5722]"
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-primary"
               >
                 {rooms.map((room) => (
                   <option key={room.id} value={room.id}>
@@ -199,7 +199,7 @@ const BookingModal = ({
                 onChange={(e) =>
                   setFormData({ ...formData, bandId: e.target.value })
                 }
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-[#FF5722]"
+                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-primary"
                 required
               >
                 <option value="">Select a band</option>
@@ -222,7 +222,7 @@ const BookingModal = ({
             </button>
             <button
               type="submit"
-              className="px-4 py-2 bg-[#FF5722] text-white rounded-md hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-[#FF5722] focus:ring-offset-2 focus:ring-offset-gray-800"
+              className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-gray-800"
             >
               {existingBooking ? 'Update' : 'Create'}
             </button>

--- a/frontend/src/components/calendar/Calendar.tsx
+++ b/frontend/src/components/calendar/Calendar.tsx
@@ -100,7 +100,7 @@ const Calendar = ({ bookings, onTimeSlotClick, loading, error }: CalendarProps) 
               onClick={() => setView('week')}
               className={`px-3 py-1 rounded-md ${
                 view === 'week'
-                  ? 'bg-[#FF5722] text-white'
+                  ? 'bg-primary text-white'
                   : 'text-gray-400 hover:text-white'
               }`}
               whileHover={{ scale: 1.05 }}
@@ -112,7 +112,7 @@ const Calendar = ({ bookings, onTimeSlotClick, loading, error }: CalendarProps) 
               onClick={() => setView('day')}
               className={`px-3 py-1 rounded-md ${
                 view === 'day'
-                  ? 'bg-[#FF5722] text-white'
+                  ? 'bg-primary text-white'
                   : 'text-gray-400 hover:text-white'
               }`}
               whileHover={{ scale: 1.05 }}
@@ -231,7 +231,7 @@ const Calendar = ({ bookings, onTimeSlotClick, loading, error }: CalendarProps) 
               onClick={() => setView('week')}
               className={`px-3 py-1 rounded-md ${
                 view === 'week'
-                  ? 'bg-[#FF5722] text-white'
+                  ? 'bg-primary text-white'
                   : 'text-gray-400 hover:text-white'
               }`}
               whileHover={{ scale: 1.05 }}
@@ -243,7 +243,7 @@ const Calendar = ({ bookings, onTimeSlotClick, loading, error }: CalendarProps) 
               onClick={() => setView('day')}
               className={`px-3 py-1 rounded-md ${
                 view === 'day'
-                  ? 'bg-[#FF5722] text-white'
+                  ? 'bg-primary text-white'
                   : 'text-gray-400 hover:text-white'
               }`}
               whileHover={{ scale: 1.05 }}

--- a/frontend/src/components/layouts/AdminLayout.tsx
+++ b/frontend/src/components/layouts/AdminLayout.tsx
@@ -37,10 +37,10 @@ const AdminLayout = ({ children }: AdminLayoutProps) => {
   };
 
   return (
-    <div className="min-h-screen text-gray-100 bg-gradient-to-br from-gray-950 via-gray-900 to-gray-800">
+    <div className="min-h-screen text-gray-100 bg-gradient-to-br from-muted-950 via-accent to-muted-950">
       {/* Sidebar */}
-      <div className="fixed inset-y-0 left-0 w-64 backdrop-blur-md bg-gradient-to-b from-slate-900 via-gray-900 to-black/80 border-r border-white/10">
-        <div className="flex h-16 items-center justify-between px-4 border-b border-white/10 bg-gradient-to-r from-cyan-500 via-sky-600 to-fuchsia-600">
+      <div className="fixed inset-y-0 left-0 w-64 backdrop-blur-md bg-gradient-to-b from-muted-950 via-primary to-muted-950 border-r border-white/10">
+        <div className="flex h-16 items-center justify-between px-4 border-b border-white/10 bg-gradient-to-r from-primary/80 via-primary to-primary/80">
           <h1 className="text-xl font-bold text-white">Admin Dashboard</h1>
           <ThemeToggle />
         </div>
@@ -60,7 +60,7 @@ const AdminLayout = ({ children }: AdminLayoutProps) => {
               >
                 <item.icon
                   className={`mr-3 h-6 w-6 flex-shrink-0 ${
-                    isActive ? 'text-[#FF5722]' : 'text-gray-400 group-hover:text-gray-300'
+                    isActive ? 'text-primary' : 'text-gray-400 group-hover:text-gray-300'
                   }`}
                 />
                 {item.name}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -52,7 +52,7 @@ const Login = () => {
                 name="email"
                 type="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-700 bg-gray-800 text-white placeholder-gray-400 rounded-t-md focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-700 bg-gray-800 text-white placeholder-gray-400 rounded-t-md focus:outline-none focus:ring-primary focus:border-primary focus:z-10 sm:text-sm"
                 placeholder="Email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -67,7 +67,7 @@ const Login = () => {
                 name="password"
                 type="password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-700 bg-gray-800 text-white placeholder-gray-400 rounded-b-md focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] focus:z-10 sm:text-sm"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-700 bg-gray-800 text-white placeholder-gray-400 rounded-b-md focus:outline-none focus:ring-primary focus:border-primary focus:z-10 sm:text-sm"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -82,7 +82,7 @@ const Login = () => {
           <div>
             <button
               type="submit"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#FF5722] hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
             >
               Sign in
             </button>

--- a/frontend/src/pages/admin/BandsPage.tsx
+++ b/frontend/src/pages/admin/BandsPage.tsx
@@ -142,7 +142,7 @@ const BandsPage = () => {
     return (
       <AdminLayout>
         <div className="flex justify-center items-center min-h-[60vh]">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#FF5722]"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
         </div>
       </AdminLayout>
     );
@@ -191,7 +191,7 @@ const BandsPage = () => {
                 setSubmitError(null);
                 setIsModalOpen(true);
               }}
-              className="block rounded-md bg-[#FF5722] px-3 py-2 text-center text-sm font-semibold text-white hover:bg-[#F4511E]"
+              className="block rounded-md bg-primary px-3 py-2 text-center text-sm font-semibold text-white hover:bg-primary/80"
             >
               <PlusIcon className="h-5 w-5 inline-block mr-1" />
               Add Band
@@ -272,7 +272,7 @@ const BandsPage = () => {
                               setSubmitError(null);
                               setIsModalOpen(true);
                             }}
-                            className="text-[#FF5722] hover:text-[#F4511E] mr-4"
+                            className="text-primary hover:text-primary/80 mr-4"
                           >
                             <PencilIcon className="h-5 w-5" />
                           </button>
@@ -339,7 +339,7 @@ const BandsPage = () => {
                     onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                     className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                       formErrors.name ? 'border-red-500' : 'border-gray-600'
-                    } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                    } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                   />
                   {formErrors.name && (
                     <p className="mt-1 text-sm text-red-500">{formErrors.name}</p>
@@ -357,7 +357,7 @@ const BandsPage = () => {
                     onChange={(e) => setFormData({ ...formData, contactEmail: e.target.value })}
                     className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                       formErrors.contactEmail ? 'border-red-500' : 'border-gray-600'
-                    } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                    } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                   />
                   {formErrors.contactEmail && (
                     <p className="mt-1 text-sm text-red-500">{formErrors.contactEmail}</p>
@@ -374,13 +374,13 @@ const BandsPage = () => {
                       setFormErrors({});
                       setSubmitError(null);
                     }}
-                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    className="px-4 py-2 text-sm font-medium text-white bg-[#FF5722] rounded-md hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-white bg-primary rounded-md hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     {editingBand ? 'Update Band' : 'Create Band'}
                   </button>
@@ -413,7 +413,7 @@ const BandsPage = () => {
                         onChange={(e) => setNewUser({ ...newUser, email: e.target.value })}
                         className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                           userErrors.email ? 'border-red-500' : 'border-gray-600'
-                        } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                        } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                       />
                       {userErrors.email && (
                         <p className="mt-1 text-sm text-red-500">{userErrors.email}</p>
@@ -431,7 +431,7 @@ const BandsPage = () => {
                         onChange={(e) => setNewUser({ ...newUser, password: e.target.value })}
                         className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                           userErrors.password ? 'border-red-500' : 'border-gray-600'
-                        } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                        } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                       />
                       {userErrors.password && (
                         <p className="mt-1 text-sm text-red-500">{userErrors.password}</p>
@@ -441,7 +441,7 @@ const BandsPage = () => {
                     <div className="flex justify-end">
                       <button
                         type="submit"
-                        className="px-4 py-2 text-sm font-medium text-white bg-[#FF5722] rounded-md hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                        className="px-4 py-2 text-sm font-medium text-white bg-primary rounded-md hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                       >
                         Add User
                       </button>

--- a/frontend/src/pages/admin/Dashboard.tsx
+++ b/frontend/src/pages/admin/Dashboard.tsx
@@ -85,7 +85,7 @@ const AdminDashboard = () => {
     return (
       <AdminLayout>
         <div className="flex justify-center items-center h-64">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#FF5722]"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
         </div>
       </AdminLayout>
     );
@@ -121,7 +121,7 @@ const AdminDashboard = () => {
                 <Link
                   key={action.name}
                   to={action.href}
-                  className="relative block w-full rounded-lg border-2 border-dashed border-gray-700 p-6 text-center hover:border-gray-600 focus:outline-none focus:ring-2 focus:ring-[#FF5722] focus:ring-offset-2"
+                  className="relative block w-full rounded-lg border-2 border-dashed border-gray-700 p-6 text-center hover:border-gray-600 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
                 >
                   <action.icon className="mx-auto h-12 w-12 text-gray-400" />
                   <span className="mt-2 block text-sm font-medium text-white">
@@ -181,7 +181,7 @@ const AdminDashboard = () => {
                           ) : null}
                           <div className="relative flex space-x-3">
                             <div>
-                              <span className="h-8 w-8 rounded-full bg-[#FF5722] flex items-center justify-center ring-8 ring-gray-800">
+                              <span className="h-8 w-8 rounded-full bg-primary flex items-center justify-center ring-8 ring-gray-800">
                                 <CalendarIcon className="h-5 w-5 text-white" aria-hidden="true" />
                               </span>
                             </div>

--- a/frontend/src/pages/admin/RoomsPage.tsx
+++ b/frontend/src/pages/admin/RoomsPage.tsx
@@ -23,7 +23,7 @@ const RoomsPage = () => {
     name: '',
     location: '',
     features: [] as string[],
-    color: '#FF5722',
+    color: '#3B82F6',
     bandIds: [] as string[],
   });
   const [formErrors, setFormErrors] = useState<{ [key: string]: string }>({});
@@ -97,7 +97,7 @@ const RoomsPage = () => {
         name: '',
         location: '',
         features: [],
-        color: '#FF5722',
+        color: '#3B82F6',
         bandIds: [],
       });
       setFormErrors({});
@@ -139,7 +139,7 @@ const RoomsPage = () => {
     return (
       <AdminLayout>
         <div className="flex justify-center items-center min-h-[60vh]">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#FF5722]"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
         </div>
       </AdminLayout>
     );
@@ -187,12 +187,12 @@ const RoomsPage = () => {
                   name: '',
                   location: '',
                   features: [],
-                  color: '#FF5722',
+                  color: '#3B82F6',
                   bandIds: [],
                 });
                 setIsModalOpen(true);
               }}
-              className="block rounded-md bg-[#FF5722] px-3 py-2 text-center text-sm font-semibold text-white hover:bg-[#F4511E]"
+              className="block rounded-md bg-primary px-3 py-2 text-center text-sm font-semibold text-white hover:bg-primary/80"
             >
               <PlusIcon className="h-5 w-5 inline-block mr-1" />
               Add Room
@@ -301,7 +301,7 @@ const RoomsPage = () => {
                                 });
                                 setIsModalOpen(true);
                               }}
-                              className="text-[#FF5722] hover:text-[#F4511E] mr-4"
+                              className="text-primary hover:text-primary/80 mr-4"
                             >
                               <PencilIcon className="h-5 w-5" />
                             </button>
@@ -338,7 +338,7 @@ const RoomsPage = () => {
                       name: '',
                       location: '',
                       features: [],
-                      color: '#FF5722',
+                      color: '#3B82F6',
                       bandIds: [],
                     });
                     setFormErrors({});
@@ -375,7 +375,7 @@ const RoomsPage = () => {
                     onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                     className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                       formErrors.name ? 'border-red-500' : 'border-gray-600'
-                    } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                    } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                   />
                   {formErrors.name && (
                     <p className="mt-1 text-sm text-red-500">{formErrors.name}</p>
@@ -393,7 +393,7 @@ const RoomsPage = () => {
                     onChange={(e) => setFormData({ ...formData, location: e.target.value })}
                     className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                       formErrors.location ? 'border-red-500' : 'border-gray-600'
-                    } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                    } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                   />
                   {formErrors.location && (
                     <p className="mt-1 text-sm text-red-500">{formErrors.location}</p>
@@ -411,7 +411,7 @@ const RoomsPage = () => {
                           type="checkbox"
                           checked={formData.features.includes(feature)}
                           onChange={() => handleFeatureChange(feature)}
-                          className="rounded border-gray-600 text-[#FF5722] focus:ring-[#FF5722] bg-gray-700"
+                          className="rounded border-gray-600 text-primary focus:ring-primary bg-gray-700"
                         />
                         <span className="ml-2 text-sm text-gray-300">{feature}</span>
                       </label>
@@ -431,7 +431,7 @@ const RoomsPage = () => {
                     id="color"
                     value={formData.color}
                     onChange={(e) => setFormData({ ...formData, color: e.target.value })}
-                    className="mt-1 block w-full h-10 rounded-md shadow-sm border border-gray-600 focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722]"
+                    className="mt-1 block w-full h-10 rounded-md shadow-sm border border-gray-600 focus:outline-none focus:ring-primary focus:border-primary"
                   />
                 </div>
 
@@ -445,19 +445,19 @@ const RoomsPage = () => {
                         name: '',
                         location: '',
                         features: [],
-                        color: '#FF5722',
+                        color: '#3B82F6',
                         bandIds: [],
                       });
                       setFormErrors({});
                       setSubmitError(null);
                     }}
-                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    className="px-4 py-2 text-sm font-medium text-white bg-[#FF5722] rounded-md hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-white bg-primary rounded-md hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     {editingRoom ? 'Update Room' : 'Create Room'}
                   </button>

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -158,7 +158,7 @@ const UsersPage = () => {
     return (
       <AdminLayout>
         <div className="flex justify-center items-center min-h-[60vh]">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#FF5722]"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
         </div>
       </AdminLayout>
     );
@@ -189,7 +189,7 @@ const UsersPage = () => {
                 resetForm();
                 setIsModalOpen(true);
               }}
-              className="block rounded-md bg-[#FF5722] px-3 py-2 text-center text-sm font-semibold text-white hover:bg-[#F4511E]"
+              className="block rounded-md bg-primary px-3 py-2 text-center text-sm font-semibold text-white hover:bg-primary/80"
             >
               <PlusIcon className="h-5 w-5 inline-block mr-1" />
               Add User
@@ -286,7 +286,7 @@ const UsersPage = () => {
                               });
                               setIsModalOpen(true);
                             }}
-                            className="text-[#FF5722] hover:text-[#F4511E] mr-4"
+                            className="text-primary hover:text-primary/80 mr-4"
                           >
                             <PencilIcon className="h-5 w-5" />
                           </button>
@@ -356,7 +356,7 @@ const UsersPage = () => {
                     }
                     className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                       formErrors.email ? 'border-red-500' : 'border-gray-600'
-                    } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                    } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                   />
                   {formErrors.email && (
                     <p className="mt-1 text-sm text-red-500">{formErrors.email}</p>
@@ -379,7 +379,7 @@ const UsersPage = () => {
                     }
                     className={`mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border ${
                       formErrors.password ? 'border-red-500' : 'border-gray-600'
-                    } focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm`}
+                    } focus:outline-none focus:ring-primary focus:border-primary sm:text-sm`}
                   />
                   {formErrors.password && (
                     <p className="mt-1 text-sm text-red-500">{formErrors.password}</p>
@@ -399,7 +399,7 @@ const UsersPage = () => {
                     onChange={(e) =>
                       setFormData({ ...formData, role: e.target.value as 'ADMIN' | 'BAND' })
                     }
-                    className="mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm"
+                    className="mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
                   >
                     <option value="ADMIN">Admin</option>
                     <option value="BAND">Band</option>
@@ -420,7 +420,7 @@ const UsersPage = () => {
                       onChange={(e) =>
                         setFormData({ ...formData, bandId: e.target.value })
                       }
-                      className="mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm"
+                      className="mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
                     >
                       <option value="">-- Select a Band --</option>
                       {bands.map((band) => (
@@ -440,13 +440,13 @@ const UsersPage = () => {
                       setEditingUser(null);
                       resetForm();
                     }}
-                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    className="px-4 py-2 text-sm font-medium text-white bg-[#FF5722] rounded-md hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-white bg-primary rounded-md hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     {editingUser ? 'Update User' : 'Create User'}
                   </button>
@@ -514,7 +514,7 @@ const UsersPage = () => {
                     id="resetEmail"
                     value={resetEmail}
                     onChange={(e) => setResetEmail(e.target.value)}
-                    className="mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-[#FF5722] focus:border-[#FF5722] sm:text-sm"
+                    className="mt-1 block w-full rounded-md shadow-sm py-2 px-3 bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
                     placeholder="Enter user email address"
                   />
                 </div>
@@ -528,13 +528,13 @@ const UsersPage = () => {
                       setResetError(null);
                       setResetSuccess(null);
                     }}
-                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    className="px-4 py-2 text-sm font-medium text-white bg-[#FF5722] rounded-md hover:bg-[#F4511E] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF5722]"
+                    className="px-4 py-2 text-sm font-medium text-white bg-primary rounded-md hover:bg-primary/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     Reset Password
                   </button>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -3,13 +3,37 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-primary: 222 90% 60%;
+    --color-muted-50: 210 100% 98%;
+    --color-muted-950: 222 35% 10%;
+  }
+
+  html[data-theme='dark'] {
+    --color-primary: 222 90% 70%;
+    --color-muted-50: 222 20% 15%;
+    --color-muted-950: 222 10% 5%;
+  }
+
   html {
     @apply scroll-smooth;
   }
   body {
-    @apply min-h-screen leading-relaxed font-sans text-gray-900 bg-gradient-to-br from-sky-50 via-teal-50 to-violet-100;
+    @apply min-h-screen leading-relaxed font-sans text-gray-900;
+    background: linear-gradient(
+      to bottom right,
+      hsl(var(--color-muted-50)),
+      hsl(var(--color-primary) / 0.3),
+      hsl(var(--color-muted-50))
+    );
   }
   html[data-theme='dark'] body {
-    @apply text-gray-100 bg-gradient-to-br from-gray-950 via-gray-900 to-gray-950;
+    @apply text-gray-100;
+    background: linear-gradient(
+      to bottom right,
+      hsl(var(--color-muted-950)),
+      hsl(var(--color-primary) / 0.3),
+      hsl(var(--color-muted-950))
+    );
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -12,6 +12,7 @@ export default {
       },
       colors: {
         primary: 'hsl(var(--color-primary))',
+        accent: 'hsl(var(--color-primary) / 0.3)',
         muted: {
           50: 'hsl(var(--color-muted-50))',
           950: 'hsl(var(--color-muted-950))',


### PR DESCRIPTION
## Summary
- introduce new pastel colour palette with CSS variables
- update layout and admin components to use new gradients
- adjust forms and buttons with `primary` colour classes
- note design update in README_DESIGN
- keep backend tests passing

## Testing
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_68598cf0147c8332831e5ebf986168d3