### PR TITLE
Improve calendar styling

### DIFF
--- a/frontend/src/pages/Calendar.tsx
+++ b/frontend/src/pages/Calendar.tsx
@@ -310,9 +310,12 @@ const CalendarPage = () => {
               center: 'title',
               right: 'dayGridMonth,timeGridWeek,timeGridDay,listWeek'
             }}
+            stickyHeaderDates={true}
             events={calendarEvents}
             eventContent={renderEventContent}
             eventClassNames={eventClassNames}
+            eventTimeFormat={{ hour: '2-digit', minute: '2-digit', hour12: false }}
+            slotLabelFormat={{ hour: '2-digit', minute: '2-digit', hour12: false }}
             eventClick={handleEventClick}
             dateClick={handleDateClick}
             selectable={true}

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -16,6 +16,27 @@
   }
   /* Event styling */
   .fc-event {
-    @apply rounded-md px-1 text-xs font-medium text-white border-0 shadow-md backdrop-blur-sm bg-opacity-80;
+    @apply rounded-md px-2 py-1 text-sm font-medium text-white border-0 shadow backdrop-blur-sm bg-opacity-80 hover:brightness-110;
+  }
+
+  /* Grid and day styling */
+  .fc-theme-standard .fc-scrollgrid,
+  .fc-theme-standard td,
+  .fc-theme-standard th {
+    @apply border-gray-700;
+  }
+  .fc-theme-standard .fc-scrollgrid {
+    @apply rounded-xl overflow-hidden;
+  }
+  .fc .fc-daygrid-day.fc-day-today,
+  .fc .fc-timegrid-col.fc-day-today {
+    @apply bg-primary/20;
+  }
+  .fc .fc-col-header-cell-cushion,
+  .fc .fc-timegrid-slot-label {
+    @apply py-2 text-gray-300 text-xs;
+  }
+  .fc .fc-toolbar-title {
+    @apply text-lg font-semibold;
   }
 }


### PR DESCRIPTION
## Summary
- modernize calendar look with larger fonts and subtle theming
- show time labels in 24-hour format
- keep calendar header sticky for easier navigation

## Testing
- `npm run lint` in frontend
- `npm run lint` in backend *(fails: parser key not supported)*
- `npm test` in frontend *(fails: vitest permission denied)*
- `npm test` in backend *(fails: jest permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6859a5bd8998833284c0a5d9140f6295