### PR TITLE
Add modern calendar page using React Big Calendar

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,24 +11,25 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.18",
-    "@heroicons/react": "^2.1.1",
-    "@reduxjs/toolkit": "^2.8.2",
-    "axios": "^1.6.7",
-    "date-fns": "^3.3.1",
     "@fullcalendar/daygrid": "^6.1.17",
     "@fullcalendar/interaction": "^6.1.17",
     "@fullcalendar/list": "^6.1.17",
     "@fullcalendar/react": "^6.1.17",
     "@fullcalendar/timegrid": "^6.1.17",
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.1",
+    "@reduxjs/toolkit": "^2.8.2",
+    "axios": "^1.6.7",
+    "date-fns": "^3.3.1",
+    "framer-motion": "^10.16.3",
     "i18next": "^23.8.2",
     "react": "^18.2.0",
+    "react-big-calendar": "^1.19.4",
     "react-dom": "^18.2.0",
     "react-i18next": "^14.0.5",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.22.0",
-    "zustand": "^4.5.0",
-    "framer-motion": "^10.16.3"
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import AdminRoute from './components/AdminRoute';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import Calendar from './pages/Calendar';
+import ModernCalendar from './pages/ModernCalendar';
 import Bands from './pages/admin/Bands';
 import RoomsPage from './pages/admin/RoomsPage';
 import UsersPage from './pages/admin/UsersPage';
@@ -58,6 +59,16 @@ const App = () => {
             <PrivateRoute>
               <Layout>
                 <Calendar />
+              </Layout>
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/calendar-modern"
+          element={
+            <PrivateRoute>
+              <Layout>
+                <ModernCalendar />
               </Layout>
             </PrivateRoute>
           }

--- a/frontend/src/pages/ModernCalendar.tsx
+++ b/frontend/src/pages/ModernCalendar.tsx
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { format, parse, startOfWeek, getDay } from 'date-fns';
+import { de } from 'date-fns/locale';
+import { fetchBookings, Booking } from '../store/slices/bookingSlice';
+import { fetchRooms } from '../store/slices/roomSlice';
+import { fetchBands } from '../store/slices/bandSlice';
+import { RootState, AppDispatch } from '../store';
+import Layout from '../components/Layout';
+import { motion } from 'framer-motion';
+
+const locales = {
+  'de': de,
+};
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 1 }),
+  getDay,
+  locales,
+});
+
+interface Event {
+  title: string;
+  start: Date;
+  end: Date;
+}
+
+const ModernCalendar = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { bookings } = useSelector((state: RootState) => state.bookings);
+  const { rooms } = useSelector((state: RootState) => state.rooms);
+  const { bands } = useSelector((state: RootState) => state.bands);
+
+  const [events, setEvents] = useState<Event[]>([]);
+
+  useEffect(() => {
+    dispatch(fetchRooms());
+    dispatch(fetchBands());
+    dispatch(fetchBookings());
+  }, [dispatch]);
+
+  useEffect(() => {
+    const evts = bookings.map((b: Booking) => {
+      const room = rooms.find(r => r.id === b.roomId);
+      const band = bands.find(br => br.id === b.bandId);
+      return {
+        title: `${band?.name || 'Band'} - ${room?.name || 'Room'}`,
+        start: new Date(b.start),
+        end: new Date(b.end),
+      } as Event;
+    });
+    setEvents(evts);
+  }, [bookings, rooms, bands]);
+
+  return (
+    <Layout>
+      <motion.div
+        className="p-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <h1 className="text-2xl font-bold text-white mb-4">Modern Calendar</h1>
+        <div className="bg-slate-900/60 backdrop-blur-md p-4 rounded-xl border border-white/10 shadow-lg">
+          <Calendar
+            localizer={localizer}
+            events={events}
+            startAccessor="start"
+            endAccessor="end"
+            style={{ height: 600 }}
+            views={[Views.MONTH, Views.WEEK, Views.DAY]}
+            popup
+          />
+        </div>
+      </motion.div>
+    </Layout>
+  );
+};
+
+export default ModernCalendar;


### PR DESCRIPTION
## Summary
- add dependency `react-big-calendar`
- create `ModernCalendar` page using `react-big-calendar` with framer-motion animations
- route `/calendar-modern` to the new calendar page

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*
- `./scripts/test-backend.sh`

------
https://chatgpt.com/codex/tasks/task_e_6859afc2be908332812501a69cb9f009